### PR TITLE
Add Django installation to post-start script

### DIFF
--- a/.devcontainer/scripts/post-start.sh
+++ b/.devcontainer/scripts/post-start.sh
@@ -19,6 +19,9 @@ bash ./pre-commit_update.sh
 # Install Poetry
 bash ./poetry.sh
 
+# Install Django
+bash ./django-install.sh
+
 # check if git template repo are up-to-date
 template_repo_status=$(bash ./git/check-merge-templates.sh)
 


### PR DESCRIPTION
This pull request adds a script to install Django in the post-start script of the .devcontainer. This ensures that Django is installed automatically when the development container is started.