### PR TITLE
Fix issue with merge staying on start

### DIFF
--- a/.devcontainer/scripts/git/check-merge-templates.sh
+++ b/.devcontainer/scripts/git/check-merge-templates.sh
@@ -20,6 +20,7 @@ function check_merge_template() {
 
     # merge branch
     if [[ $merge_message == "Already up to date." ]]; then
+        git merge --abort
         echo -e "up-to-date"
     else
         # abort merge


### PR DESCRIPTION
When starting the devcontainer, merges can sometimes stay. This pull request fixes the issue by adding a command to abort the merge if the merge message is "Already up to date." This ensures that merges are not stuck on the start.

Fixes #14